### PR TITLE
Added JRPiCam as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "jrpicam"]
+	path = jrpicam
+	url = https://github.com/Hopding/JRPiCam.git

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
     repositories {
         mavenCentral()
     }
+
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:1.4.2.RELEASE")
     }
@@ -111,6 +112,7 @@ repositories {
 }
 
 dependencies {
+    compile project(':jrpicam')
     compile(group: "org.springframework.boot", name: "spring-boot-starter-web") {
         exclude(module: "spring-boot-starter-tomcat")
         exclude(group: "org.hibernate")
@@ -121,4 +123,3 @@ dependencies {
     testCompile(group: 'junit', name: 'junit', version: '4.12')
     testCompile(group: 'org.mockito', name: 'mockito-core', version: '1.8.5')
 }
-

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,2 @@
 rootProject.name = 'image_tracker'
+include 'jrpicam'

--- a/src/main/java/csci432/Main.java
+++ b/src/main/java/csci432/Main.java
@@ -1,4 +1,5 @@
 package csci432;
+import com.hopding.jrpicam.*;
 
 public class Main {
     /**


### PR DESCRIPTION
Seems a little messy, but everything compiles nicely.
+ Examples from JRPICam are included in the source tree. Should they be removed in some fashion?